### PR TITLE
Fix colorama init

### DIFF
--- a/ufo/utils/__init__.py
+++ b/ufo/utils/__init__.py
@@ -7,9 +7,11 @@ import os
 from io import BytesIO
 from typing import Optional
 
-from colorama import Fore, Style
+from colorama import Fore, Style, init
 from PIL import Image
 
+# init colorama
+init()
 
 def print_with_color(text: str, color: str = ""):
     """


### PR DESCRIPTION
Fix Colorama coloring on Windows console command prompt and power shell. Before fix there was no coloring on console.

Environment:
Windows 11  Version 22H2 Builld 22621.3155

Python Version: 3.10.13

Installed Packages:
annotated-types==0.6.0
anyio==4.2.0
art==6.1
certifi==2024.2.2
cffi==1.16.0
charset-normalizer==3.3.2
colorama==0.4.6
comtypes==1.3.0
cryptography==42.0.3
distro==1.9.0
exceptiongroup==1.2.0
h11==0.14.0
httpcore==1.0.3
httpx==0.26.0
idna==3.6
msal==1.25.0
openai==1.11.1
pillow==10.2.0
pycparser==2.21
pydantic==2.6.1
pydantic_core==2.16.2
PyJWT==2.8.0
pywin32==306
pywinauto==0.6.8
PyYAML==6.0.1
requests==2.31.0
six==1.16.0
sniffio==1.3.0
tqdm==4.66.2
typing_extensions==4.9.0
urllib3==2.2.1
