### PR TITLE
Fix typo in api README.md

### DIFF
--- a/model_worker/README.md
+++ b/model_worker/README.md
@@ -16,7 +16,7 @@ pip install -U google-generativeai==0.7.0
     "API_MODEL": "YOUR_MODEL"
 }
 ```
-NOTE: `API_MODEL` is the model name of QWen LLM API. 
+NOTE: `API_MODEL` is the model name of Gemini LLM API. 
 You can find the model name in the [Gemini LLM model list](https://ai.google.dev/gemini-api).
 If you meet the `429 Resource has been exhausted (e.g. check quota).`, it may because the rate limit of your Gemini API.
 


### PR DESCRIPTION
Typo when copying Qwen api to Gemini api