### PR TITLE
`Chore` Use OpenAI GPT-4o-mini model by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ VISUAL_MODE: True, # Whether to use the visual mode
 API_TYPE: "openai" , # The API type, "openai" for the OpenAI API.  
 API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint.
 API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The only OpenAI model
+API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 ```
 
 #### Azure OpenAI (AOAI)
@@ -119,8 +119,8 @@ VISUAL_MODE: True, # Whether to use the visual mode
 API_TYPE: "aoai" , # The API type, "aoai" for the Azure OpenAI.  
 API_BASE: "YOUR_ENDPOINT", #  The AOAI API address. Format: https://{your-resource-name}.openai.azure.com
 API_KEY: "YOUR_KEY",  # The aoai API key
-API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The only OpenAI model
+API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 API_DEPLOYMENT_ID: "YOUR_AOAI_DEPLOYMENT", # The deployment id for the AOAI API
 ```
 You can also non-visial model (e.g., GPT-4) for each agent, by setting `VISUAL_MODE: False` and proper `API_MODEL` (openai) and `API_DEPLOYMENT_ID` (aoai). You can also optionally set an backup LLM engine in the field of `BACKUP_AGENT` if the above engines failed during the inference.

--- a/documents/docs/configurations/pricing_configuration.md
+++ b/documents/docs/configurations/pricing_configuration.md
@@ -18,6 +18,8 @@ PRICES: {
     "openai/gpt-4-turbo": {"input":0.01,"output": 0.03},
     "openai/gpt-4o": {"input": 0.005,"output": 0.015},
     "openai/gpt-4o-2024-05-13": {"input": 0.005, "output": 0.015},
+    "openai/gpt-4o-mini": {"input": 0.00015,"output": 0.0006},
+    "openai/gpt-4o-mini-2024-07-18": {"input": 0.00015,"output": 0.0006},
     "openai/gpt-3.5-turbo-0125": {"input": 0.0005, "output": 0.0015},
     "openai/gpt-3.5-turbo-1106": {"input": 0.001, "output": 0.002},
     "openai/gpt-3.5-turbo-instruct": {"input": 0.0015, "output": 0.002},

--- a/documents/docs/configurations/user_configuration.md
+++ b/documents/docs/configurations/user_configuration.md
@@ -14,8 +14,8 @@ Below are the configuration options for the LLMs, using OpenAI and Azure OpenAI 
 | `API_TYPE` | The API type: "openai" for the OpenAI API, "aoai" for the AOAI API. | String | "openai" |
 | `API_BASE` | The API endpoint for the LLM | String | "https://api.openai.com/v1/chat/completions" |
 | `API_KEY` | The API key for the LLM | String | "sk-" |
-| `API_VERSION` | The version of the API | String | "2024-02-15-preview" |
-| `API_MODEL` | The LLM model name | String | "gpt-4-vision-preview" |
+| `API_VERSION` | The version of the API | String | "gpt-4o-mini-2024-07-18" |
+| `API_MODEL` | The LLM model name | String | "gpt-4o-mini" |
 
 ### For Azure OpenAI (AOAI) API
 The following additional configuration option is available for the AOAI API:

--- a/documents/docs/getting_started/quick_start.md
+++ b/documents/docs/getting_started/quick_start.md
@@ -24,8 +24,8 @@ VISUAL_MODE: True, # Whether to use the visual mode
 API_TYPE: "openai" , # The API type, "openai" for the OpenAI API.  
 API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint.
 API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The OpenAI model
+API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 ```
 
 
@@ -35,8 +35,8 @@ VISUAL_MODE: True, # Whether to use the visual mode
 API_TYPE: "aoai" , # The API type, "aoai" for the Azure OpenAI.  
 API_BASE: "YOUR_ENDPOINT", #  The AOAI API address. Format: https://{your-resource-name}.openai.azure.com
 API_KEY: "YOUR_KEY",  # The aoai API key
-API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The OpenAI model
+API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 API_DEPLOYMENT_ID: "YOUR_AOAI_DEPLOYMENT", # The deployment id for the AOAI API
 ```
 You can also non-visial model (e.g., GPT-4) for each agent, by setting `VISUAL_MODE: False` and proper `API_MODEL` (openai) and `API_DEPLOYMENT_ID` (aoai). You can also optionally set an backup LLM engine in the field of `BACKUP_AGENT` if the above engines failed during the inference. The `API_MODEL` can be any GPT models that can accept images as input.

--- a/documents/docs/supported_models/azure_openai.md
+++ b/documents/docs/supported_models/azure_openai.md
@@ -11,8 +11,8 @@ VISUAL_MODE: True, # Whether to use visual mode to understand screenshots and ta
 API_TYPE: "aoai" , # The API type, "openai" for the OpenAI API, "aoai" for the AOAI API, 'azure_ad' for the ad authority of the AOAI API.  
 API_BASE: "YOUR_ENDPOINT", #  The AOAI API address. Format: https://{your-resource-name}.openai.azure.com
 API_KEY: "YOUR_KEY",  # The aoai API key
-API_VERSION: "2024-02-15-preview", # The version of the API, "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The OpenAI model name, "gpt-4-vision-preview" by default. You may also use "gpt-4o" for using the GPT-4O model.
+API_VERSION: "gpt-4o-mini-2024-07-18", # The version of the API, "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 API_DEPLOYMENT_ID: "YOUR_AOAI_DEPLOYMENT", # The deployment id for the AOAI API
 ```
 

--- a/documents/docs/supported_models/openai.md
+++ b/documents/docs/supported_models/openai.md
@@ -13,8 +13,8 @@ VISUAL_MODE: True, # Whether to use visual mode to understand screenshots and ta
 API_TYPE: "openai" , # The API type, "openai" for the OpenAI API, "aoai" for the AOAI API, 'azure_ad' for the ad authority of the AOAI API.  
 API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API.
 API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-API_VERSION: "2024-02-15-preview", # The version of the API, "2024-02-15-preview" by default
-API_MODEL: "gpt-4-vision-preview",  # The OpenAI model name, "gpt-4-vision-preview" by default. You may also use "gpt-4o" for using the GPT-4O model.
+API_VERSION: "gpt-4o-mini-2024-07-18", # The version of the API, "gpt-4o-mini-2024-07-18" by default
+API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 ```
 
 !!! tip

--- a/ufo/config/config.yaml.template
+++ b/ufo/config/config.yaml.template
@@ -4,15 +4,15 @@ HOST_AGENT: {
   API_TYPE: "openai" , # The API type, "openai" for the OpenAI API, "aoai" for the AOAI API, 'azure_ad' for the ad authority of the AOAI API.  
   API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API.
   API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-  API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-  API_MODEL: "gpt-4-vision-preview",  # The only OpenAI model by now that accepts visual input
+  API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+  API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 
 
   ### Comment above and uncomment these if using "aoai".
   # API_TYPE: "aoai" , # The API type, "openai" for the OpenAI API, "aoai" for the Azure OpenAI.  
   # API_BASE: "YOUR_ENDPOINT", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API. As for the aoai, it should be https://{your-resource-name}.openai.azure.com
   # API_KEY: "YOUR_KEY",  # The aoai API key
-  # API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
+  # API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
   # API_MODEL: "YOUR_MODEL",  # The only OpenAI model by now that accepts visual input
   # API_DEPLOYMENT_ID: "gpt-4-visual-preview", # The deployment id for the AOAI API
   
@@ -28,15 +28,15 @@ APP_AGENT: {
   API_TYPE: "openai" , # The API type, "openai" for the OpenAI API, "aoai" for the AOAI API, 'azure_ad' for the ad authority of the AOAI API.  
   API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API.
   API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-  API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-  API_MODEL: "gpt-4-vision-preview",  # The only OpenAI model by now that accepts visual input
+  API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+  API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 
 
   ### Comment above and uncomment these if using "aoai".
   # API_TYPE: "aoai" , # The API type, "openai" for the OpenAI API, "aoai" for the Azure OpenAI.  
   # API_BASE: "YOUR_ENDPOINT", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API. As for the aoai, it should be https://{your-resource-name}.openai.azure.com
   # API_KEY: "YOUR_KEY",  # The aoai API key
-  # API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
+  # API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
   # API_MODEL: "YOUR_MODEL",  # The only OpenAI model by now that accepts visual input
   # API_DEPLOYMENT_ID: "gpt-4-visual-preview", # The deployment id for the AOAI API
   
@@ -52,15 +52,15 @@ BACKUP_AGENT: {
   API_TYPE: "openai" , # The API type, "openai" for the OpenAI API, "aoai" for the AOAI API, 'azure_ad' for the ad authority of the AOAI API.  
   API_BASE: "https://api.openai.com/v1/chat/completions", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API.
   API_KEY: "sk-",  # The OpenAI API key, begin with sk-
-  API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
-  API_MODEL: "gpt-4-vision-preview",  # The only OpenAI model by now that accepts visual input
+  API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
+  API_MODEL: "gpt-4o-mini", # The OpenAI model name, "gpt-4o-mini" by default. You may also use "gpt-4o" for using the GPT-4O model.
 
 
   ### Comment above and uncomment these if using "aoai".
   # API_TYPE: "aoai" , # The API type, "openai" for the OpenAI API, "aoai" for the Azure OpenAI.  
   # API_BASE: "YOUR_ENDPOINT", # The the OpenAI API endpoint, "https://api.openai.com/v1/chat/completions" for the OpenAI API. As for the aoai, it should be https://{your-resource-name}.openai.azure.com
   # API_KEY: "YOUR_KEY",  # The aoai API key
-  # API_VERSION: "2024-02-15-preview", # "2024-02-15-preview" by default
+  # API_VERSION: "gpt-4o-mini-2024-07-18", # "gpt-4o-mini-2024-07-18" by default
   # API_MODEL: "YOUR_MODEL",  # The only OpenAI model by now that accepts visual input
   # API_DEPLOYMENT_ID: "gpt-4-visual-preview", # The deployment id for the AOAI API
   


### PR DESCRIPTION
UFO uses the `gpt-4-vision-preview` model name as a default.

This is now sorely outdated as per the [Deprecation history document by OpenAI](https://platform.openai.com/docs/deprecations).

> On June 6th, 2024, we notified developers using gpt-4-32k and gpt-4-vision-preview of their upcoming deprecations in one year and six months respectively.
> As of June 17, 2024, only existing users of these models will be able to continue using them.

This has caused various experimenting users to be unable to "see" or "find" the `...-preview` model (they probably had not used it prior to June 17, 2024.

For this reason, this PR introduces a default of `gpt-4o-mini` which is performant yet quite cheaper than the `gpt-4o` visual model by OpenAI.