### PR TITLE
Fixed `can't set attribute 'results'` during exit

### DIFF
--- a/ufo/module/basic.py
+++ b/ufo/module/basic.py
@@ -540,6 +540,10 @@ class BaseSession(ABC):
         """
         return self._results
 
+    @results.setter
+    def results(self, value):
+        self._results = value
+
     def experience_saver(self) -> None:
         """
         Save the current trajectory as agent experience.


### PR DESCRIPTION
Fixed `can't set attribute 'results'` during exit