### PR TITLE
Fix: ID collision issue in merged control list

### DIFF
--- a/ufo/agents/processors/strategies/app_agent_processing_strategy.py
+++ b/ufo/agents/processors/strategies/app_agent_processing_strategy.py
@@ -458,6 +458,10 @@ class AppControlInfoStrategy(BaseProcessingStrategy):
                 f"Collected {len(merged_control_list)} controls after merging."
             )
 
+            # FIX: allocate new IDs for the merged controls
+            for i, control in enumerate(merged_control_list, start=1):
+                control.id = str(i)
+
             target_registry.register(merged_control_list)
 
             # Step 4: Taking annotated screenshot.


### PR DESCRIPTION
For uia control list, you have assigned id
```python
# UFO/ufo/client/mcp/local_servers/ui_mcp_server.py:780-798
controls_list = ui_state.control_inspector.find_control_elements_in_descendants(
    ui_state.selected_app_window,
    control_type_list=configs.get("CONTROL_LIST", []),
    class_name_list=configs.get("CONTROL_LIST", []),
)

# uia control ID allocation: "1", "2", "3", "4"...
control_dict = {str(i + 1): control for i, control in enumerate(controls_list)}

target_info_list = []
for id, control in control_dict.items():
    control_info = ui_state.control_inspector.get_control_info(control, field_list)
    target_info_list.append(
        TargetInfo(
            kind=TargetKind.CONTROL,
            id=str(id),  # id assigned here
            # ... other property
        )
    )
```
But for omniparser grounding control list, there is no id assigned, so the default value would be None
```python
# UFO/ufo/automator/ui_control/grounding/omniparser.py:240-250
for control_info in results:
    control_element = self._calculate_absolute_coordinates(
        control_info, app_left, app_top, app_width, app_height
    )
    if control_element is not None:
        control_elements_info.append(
            TargetInfo(
                kind=TargetKind.CONTROL,
                type=control_element.get("control_type", "Button"),
                name=control_element.get("name", ""),
                rect=(...),
                # There is no id assigned, and TargetInfo class ill assign None as the default value
            )
        )
```
Then after you merge the control list, actually the control id in the merged control list would be like
```
['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]
```
There are 33 uia controls and 38 omniparser controls, then you call target_registry.register(merged_control_list), in this function, all the first 33 None id would convert into 1~33, which is already registered (the uia controls)
```python
# UFO\ufo\agents\processors\schemas\target.py: 45-68
    def register(self, target: Union[TargetInfo, List[TargetInfo]]) -> List[TargetInfo]:
        """
        Register a target or a list of targets.
        :param target: The target or list of targets to register.
        :return: A list of registered targets.
        """
        if not isinstance(target, list):
            target = [target]

        registered = []
        for t in target:
            if not t.id:  
                self._counter += 1 # this will generate id 1~33 for None
                t.id = str(self._counter)

            if t.id in self._targets: # and then id 1~33 has already been registered, these controls are ignored
                self.logger.warning(
                    f"Target with ID {t.id} is already registered, ignoring.",
                )
            else:
                self._targets[t.id] = t
                registered.append(t)

        return registered
```
This will cause some control failed be annotated in the screenshot, but stored in the annotation_dict, this may cause some error