### PR TITLE
Fix: Correct TargetInfo rect format assumption in IOU calculation

### DIFF
--- a/ufo/automator/ui_control/screenshot.py
+++ b/ufo/automator/ui_control/screenshot.py
@@ -1068,15 +1068,15 @@ class PhotographerFacade:
         if not target1.rect or not target2.rect:
             return 0.0
 
-        # TargetInfo rect format: [left, top, width, height]
-        # Convert to [left, top, right, bottom] for calculation
-        rect1_left, rect1_top, rect1_width, rect1_height = target1.rect
-        rect1_right = rect1_left + rect1_width
-        rect1_bottom = rect1_top + rect1_height
+        # TargetInfo rect format: [left, top, right, bottom] (absolute coordinates)
+        rect1_left, rect1_top, rect1_right, rect1_bottom = target1.rect
+        rect2_left, rect2_top, rect2_right, rect2_bottom = target2.rect
 
-        rect2_left, rect2_top, rect2_width, rect2_height = target2.rect
-        rect2_right = rect2_left + rect2_width
-        rect2_bottom = rect2_top + rect2_height
+        # Calculate width and height
+        rect1_width = rect1_right - rect1_left
+        rect1_height = rect1_bottom - rect1_top
+        rect2_width = rect2_right - rect2_left
+        rect2_height = rect2_bottom - rect2_top
 
         # Calculate intersection
         left = max(rect1_left, rect2_left)


### PR DESCRIPTION
```python
# UFO\ufo\automator\ui_control\screenshot.py: 1060-1079
    def target_info_iou(target1: "TargetInfo", target2: "TargetInfo") -> float:
        """
        Calculate the IOU overlap between two TargetInfo objects.
        :param target1: The first target.
        :param target2: The second target.
        :return: The IOU overlap.
        """
        # Check if both targets have valid rect information
        if not target1.rect or not target2.rect:
            return 0.0

        # TargetInfo rect format: [left, top, width, height] <-this is not correct, should be [[left, top, right, bottom]
        # Convert to [left, top, right, bottom] for calculation <- this calculation should be fixed
        rect1_left, rect1_top, rect1_width, rect1_height = target1.rect
        rect1_right = rect1_left + rect1_width
        rect1_bottom = rect1_top + rect1_height

        rect2_left, rect2_top, rect2_width, rect2_height = target2.rect
        rect2_right = rect2_left + rect2_width
        rect2_bottom = rect2_top + rect2_height
...
```