### PR TITLE
ci: pin document deploy workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/document_deploy.yml
+++ b/.github/workflows/document_deploy.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e
         with:
           python-version: '3.9'
 


### PR DESCRIPTION
## Summary
- pin the two floating actions in `.github/workflows/document_deploy.yml` to immutable SHAs
- preserve the existing MkDocs deploy behavior and workflow scope
- keep the change one-file and targeted to `pre-release` per the contributor guide

## Validation
- `git diff --check`
- `python -c "import pathlib, yaml; p=pathlib.Path(r'.github/workflows/document_deploy.yml'); yaml.safe_load(p.read_text(encoding='utf-8')); print('yaml_ok', p)"`
- final exact-file overlap recheck on open `pre-release` PRs found no other open PR touching `.github/workflows/document_deploy.yml`

## Notes
- contributor guidance says PRs should target `pre-release`, and this PR follows that
- this is a one-file workflow hardening pass only; no runtime or docs changes
- prepared with AI assistance and manually validated before submission