### PR TITLE
fix: replace bare except clauses in WinCOMReceiverBasic

### DIFF
--- a/ufo/automator/app_apis/basic.py
+++ b/ufo/automator/app_apis/basic.py
@@ -97,7 +97,7 @@ class WinCOMReceiverBasic(ReceiverBasic):
         try:
             full_path = self.com_object.FullName
             return full_path
-        except:
+        except Exception:
             return ""
 
     def save(self) -> None:
@@ -106,7 +106,7 @@ class WinCOMReceiverBasic(ReceiverBasic):
         """
         try:
             self.com_object.Save()
-        except:
+        except Exception:
             pass
 
     def save_to_xml(self, file_path: str) -> None:
@@ -116,7 +116,7 @@ class WinCOMReceiverBasic(ReceiverBasic):
         """
         try:
             self.com_object.SaveAs(file_path, self.xml_format_code)
-        except:
+        except Exception:
             pass
 
     def close(self) -> None:
@@ -125,7 +125,7 @@ class WinCOMReceiverBasic(ReceiverBasic):
         """
         try:
             self.com_object.Close()
-        except:
+        except Exception:
             pass
 
     @property


### PR DESCRIPTION
## Summary

- Replace bare `except:` with `except Exception:` in `WinCOMReceiverBasic` methods

## Changes

`ufo/automator/app_apis/basic.py` — four methods (`full_path`, `save`, `save_to_xml`, `close`) used bare `except:` clauses which catch all exceptions including `SystemExit` and `KeyboardInterrupt`. Changed to `except Exception:` to only suppress non-system exceptions, matching the pattern used elsewhere in the codebase.

## Motivation

Bare `except:` clauses can unintentionally suppress interpreter-level signals and make debugging harder. PEP 8 explicitly recommends against them.