### PR TITLE
fix: prevent UnboundLocalError in ExperienceSummarizer.get_summary

### DIFF
--- a/ufo/experience/summarizer.py
+++ b/ufo/experience/summarizer.py
@@ -74,12 +74,12 @@ class ExperienceSummarizer:
         )
         try:
             response_json = json_parser(response_string)
-        except:
+        except Exception:
             response_json = None
 
         # Restructure the response
+        summary = dict()
         if response_json:
-            summary = dict()
             summary["example"] = {}
             for key in [
                 "Observation",


### PR DESCRIPTION
## Summary

- Fix `UnboundLocalError: cannot access local variable 'summary'` in `ExperienceSummarizer.get_summary`
- Replace bare `except:` with `except Exception:`

## Changes

`ufo/experience/summarizer.py` — when `json_parser` raises an exception, `response_json` is set to `None` and the `summary` dict is never initialized inside the `if response_json:` block. The subsequent `return summary, cost` then raises `UnboundLocalError`.

Fix: initialize `summary = dict()` before the conditional block so it is always defined regardless of whether `json_parser` succeeds.

## Reproduction

```
UserWarning: cannot access local variable 'summary' where it is not associated with a value
```

Occurs when the LLM returns a non-JSON response during experience summarization.

## Related Issue

Fixes #189