### PR TITLE
fix: replace bare except clause in ClaudeService.chat_completion

### DIFF
--- a/ufo/llm/claude.py
+++ b/ufo/llm/claude.py
@@ -86,7 +86,7 @@ class ClaudeService(BaseService):
                     logger.error(f"Error when making API request: {error_trace}")
                     try:
                         logger.error(response)
-                    except:
+                    except Exception:
                         pass
                     time.sleep(3)
                     continue


### PR DESCRIPTION
## Summary

- Replace bare `except:` with `except Exception:` in `ClaudeService.chat_completion`

## Changes

`ufo/llm/claude.py` — the fallback `try/except` block that logs the raw `response` object on API error used a bare `except:` clause. Changed to `except Exception:` to avoid suppressing `SystemExit` or `KeyboardInterrupt`.

The outer exception handler already uses `except Exception as e` (correct); this aligns the inner fallback with the same pattern.