### PR TITLE
fix: replace bare except clause in AppPuppeteer.get_command_types

### DIFF
--- a/ufo/automator/puppeteer.py
+++ b/ufo/automator/puppeteer.py
@@ -67,7 +67,7 @@ class AppPuppeteer:
                 command_name
             )
             return receiver.type_name
-        except:
+        except Exception:
             return ""
 
     def execute_command(


### PR DESCRIPTION
## Summary

- Replace bare `except:` with `except Exception:` in `AppPuppeteer.get_command_types`

## Changes

`ufo/automator/puppeteer.py` — `get_command_types` used a bare `except:` clause when the receiver lookup fails. Changed to `except Exception:` to avoid inadvertently suppressing `SystemExit` or `KeyboardInterrupt`.