### PR TITLE
fix: replace bare except clauses in LlavaService and CogAgentService

### DIFF
--- a/ufo/llm/cogagent.py
+++ b/ufo/llm/cogagent.py
@@ -81,7 +81,7 @@ class CogAgentService(BaseService):
                     logger.error(f"Error making API request: {e}")
                     try:
                         logger.error(response)
-                    except:
+                    except Exception:
                         pass
                     time.sleep(3)
                     continue

--- a/ufo/llm/llava.py
+++ b/ufo/llm/llava.py
@@ -94,7 +94,7 @@ class LlavaService(BaseService):
                     logger.error(f"Error making API request: {e}")
                     try:
                         logger.error(response)
-                    except:
+                    except Exception:
                         pass
                     time.sleep(3)
                     continue


### PR DESCRIPTION
## Summary

- Replace bare `except:` with `except Exception:` in `LlavaService` and `CogAgentService`

## Changes

`ufo/llm/llava.py` and `ufo/llm/cogagent.py` — both services share the same retry pattern: on API error the outer `except Exception as e` logs the error, then a nested `try/except` attempts to log the raw `response` object. The inner except was bare, which can suppress `SystemExit` and `KeyboardInterrupt`. Changed to `except Exception:` to match the outer handler.