### PR TITLE
fix: add return type annotation to type_name property in WinCOMReceiverBasic

### DIFF
--- a/ufo/automator/app_apis/basic.py
+++ b/ufo/automator/app_apis/basic.py
@@ -129,7 +129,7 @@ class WinCOMReceiverBasic(ReceiverBasic):
             pass
 
     @property
-    def type_name(self):
+    def type_name(self) -> str:
         return "COM"
 
     @property


### PR DESCRIPTION
## Summary

- Add missing `-> str` return type annotation to the `type_name` property in `WinCOMReceiverBasic`

## Changes

- `ufo/automator/app_apis/basic.py`: annotate `type_name` property with `-> str` to match the existing pattern of other typed properties in the class

## Related Issue

No open issue — spotted during code review of `WinCOMReceiverBasic`.