### PR TITLE
fix: remove duplicate description setter in TaskStar

### DIFF
--- a/galaxy/constellation/task_star.py
+++ b/galaxy/constellation/task_star.py
@@ -172,21 +172,6 @@ class TaskStar(ITask):
         self._tips = value
         self._updated_at = datetime.now(timezone.utc)
 
-    @description.setter
-    def description(self, value: str) -> None:
-        """
-        Set the task description.
-
-        :param value: New task description
-        :raises ValueError: If task is currently running
-        """
-        if self._status == TaskStatus.RUNNING:
-            raise ValueError(
-                f"Cannot modify description of running task {self._task_id}"
-            )
-        self._description = value
-        self._updated_at = datetime.now(timezone.utc)
-
     async def execute(
         self, device_manager: ConstellationDeviceManager
     ) -> ExecutionResult:


### PR DESCRIPTION
## Summary

- Remove a duplicate `@description.setter` definition in `TaskStar` that silently overrides the first one

## Changes

- `galaxy/constellation/task_star.py`: delete the second `@description.setter` block (lines 175–188); the first definition (lines 142–155) is identical and takes effect correctly

## Related Issue

No open issue — the duplicate setter is a latent bug: Python uses the last definition, so any difference between the two would cause silent misbehaviour.