### PR TITLE
fix: guard against None cost when using local LLMs without pricing

### DIFF
--- a/ufo/module/basic.py
+++ b/ufo/module/basic.py
@@ -743,7 +743,7 @@ class BaseSession(ABC):
             summaries, os.path.join(experience_path, "experience_db")
         )
 
-        self.cost += cost
+        self.cost += cost or 0
         self.logger.info(f"The experience has been saved to {experience_path}")
 
     def print_cost(self) -> None:
@@ -848,7 +848,7 @@ class BaseSession(ABC):
 
         self._results.append(result)
 
-        self.cost += cost
+        self.cost += cost or 0
 
         evaluator.print_response(result)
 


### PR DESCRIPTION
## Summary

- Fix `TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'` crash when using local LLM providers (e.g. Ollama) that return `None` for cost

## Changes

- `ufo/module/basic.py`: replace `self.cost += cost` with `self.cost += cost or 0` in both `save_experience` and `evaluation` methods — local LLMs do not return a cost value, so `cost` is `None`

## Related Issue

Fixes #186