### PR TITLE
fix: replace bare except with json.JSONDecodeError in trajectory parser

### DIFF
--- a/ufo/trajectory/parser.py
+++ b/ufo/trajectory/parser.py
@@ -155,7 +155,7 @@ class Trajectory:
 
                 try:
                     evaluation_data = json.load(file)
-                except:
+                except json.JSONDecodeError:
                     evaluation_data = {}
 
         else:


### PR DESCRIPTION
## Summary

- Replace a bare `except:` clause with `except json.JSONDecodeError:` in the trajectory parser's evaluation log loader

## Changes

- `ufo/trajectory/parser.py`: narrow the exception catch in `_load_evaluation_data` from bare `except` to `json.JSONDecodeError` — the only error `json.load` raises for malformed input; a bare except would silently swallow unrelated errors (e.g. `IOError`, `PermissionError`) and hide data corruption issues

## Related Issue

No open issue — identified as a code quality improvement in `ufo/trajectory/parser.py`.