### PR TITLE
fix: guard against None control in ControlPhotographer.capture

### DIFF
--- a/ufo/automator/ui_control/screenshot.py
+++ b/ufo/automator/ui_control/screenshot.py
@@ -79,12 +79,17 @@ class ControlPhotographer(Photographer):
         """
         self.control = control
 
-    def capture(self, save_path: str = None, scalar: List[int] = None) -> Image.Image:
+    def capture(self, save_path: str = None, scalar: List[int] = None) -> Optional[Image.Image]:
         """
         Capture a screenshot.
         :param save_path: The path to save the screenshot.
-        :return: The screenshot.
+        :param scalar: Optional rescale dimensions [width, height].
+        :return: The screenshot, or None if the control is unavailable.
         """
+        if self.control is None:
+            logger.warning("Cannot capture screenshot: control element is None.")
+            return None
+
         # Capture single window screenshot
         screenshot = self.control.capture_as_image()
         if scalar is not None:


### PR DESCRIPTION
## Summary

When an application window closes or becomes unavailable between the time it is identified and the screenshot capture step, the `UIAWrapper` control element can be `None`. Calling `.capture_as_image()` on a `None` object raises:

```
AttributeError: 'NoneType' object has no attribute 'capture_as_image'
```

This crash surfaces in the `AppAgent` screenshot step and terminates the agent loop unexpectedly.

## Changes

- Added a `None` guard at the top of `ControlPhotographer.capture()` in `ufo/automator/ui_control/screenshot.py`
- Logs a warning and returns `None` when the control is unavailable, allowing callers to handle the missing screenshot gracefully

## Testing

The fix follows the existing pattern used throughout the codebase (`if save_path is not None and screenshot is not None`) and is consistent with the `DesktopPhotographer` and other photographer variants which already return `None` on failure.

Closes #232