### PR TITLE
fix: handle COMError in wait_enabled when UI element becomes stale

### DIFF
--- a/ufo/automator/ui_control/controller.py
+++ b/ufo/automator/ui_control/controller.py
@@ -365,7 +365,16 @@ class ControlReceiver(ReceiverBasic):
         :param timeout: The timeout to wait.
         :param retry_interval: The retry interval to wait.
         """
-        while not self.control.is_enabled():
+        while True:
+            try:
+                if self.control.is_enabled():
+                    break
+            except Exception as e:
+                logger.warning(
+                    f"Exception while checking if control is enabled, "
+                    f"assuming it is ready: {e}"
+                )
+                break
             time.sleep(retry_interval)
             timeout -= retry_interval
             if timeout <= 0:


### PR DESCRIPTION
## Summary

Selecting an item from a dropdown (or any interaction that triggers a UI state change) can invalidate the underlying COM automation element. The subsequent `is_enabled()` poll in `wait_enabled()` then raises a `COMError` and crashes the agent loop:

```
_ctypes.COMError: (-2147220991, 'An event was unable to invoke any of the subscribers', ...)
```

Traceback from the issue:
```
File "ufo/automator/ui_control/controller.py", line 346, in wait_enabled
    while not self.control.is_enabled():
_ctypes.COMError: (-2147220991, ...)
```

## Changes

- Wrapped the `is_enabled()` call in `wait_enabled()` inside a `try/except Exception` block in `ufo/automator/ui_control/controller.py`
- On any exception (including `COMError`), logs a warning and breaks out of the wait loop, treating the element as ready
- The timeout logic is preserved for the non-exception path

## Testing

Reproduced by selecting an option from a dropdown menu in an application that triggers a UI rebuild. The fix allows the agent to continue execution after dropdown selection instead of crashing.

Closes #246