### PR TITLE
fix: guard against empty/filtered LLM responses in OpenAI client

### DIFF
--- a/ufo/llm/openai.py
+++ b/ufo/llm/openai.py
@@ -204,6 +204,8 @@ class BaseOpenAIService(BaseService):
                     completion_tokens,
                 )
 
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 return [response.choices[0].message.content], cost
 
         except openai.APITimeoutError as e:


### PR DESCRIPTION
## What

Adds a null check in `ufo/llm/openai.py` before accessing `response.choices[0].message`.

## Why

Two silent failure modes crash at this line:

1. **`IndexError`** — `choices` is an empty list when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (some providers return HTTP 200 with a filtered finish reason)

## Fix

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return [response.choices[0].message.content], cost
```

Detected by [pact](https://github.com/qizwiz/pact) static analysis.