### PR TITLE
Feat/add litellm provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ langchain==0.3.27
 langchain_community==0.3.29
 msal==1.31.0
 openai==1.66.2
+litellm>=1.80,<1.87
 Pillow==11.3.0
 PyPDF2==3.0.1; sys_platform == 'win32'
 protobuf==4.25.8

--- a/ufo/llm/base.py
+++ b/ufo/llm/base.py
@@ -42,6 +42,7 @@ class BaseService(abc.ABC):
             "custom": "CustomService",
             "operator": "OperatorServicePreview",
             "placeholder": "PlaceHolderService",
+            "litellm": "LiteLLMService",
         }
         custom_service_map = {
             "llava": "LlavaService",
@@ -145,6 +146,8 @@ class BaseService(abc.ABC):
             name = str("gemini/" + model)
         elif api_type.lower() == "claude":
             name = str("claude/" + model)
+        elif api_type.lower() == "litellm":
+            name = str("litellm/" + model)
         else:
             name = model
 

--- a/ufo/llm/base.py
+++ b/ufo/llm/base.py
@@ -147,7 +147,7 @@ class BaseService(abc.ABC):
         elif api_type.lower() == "claude":
             name = str("claude/" + model)
         elif api_type.lower() == "litellm":
-            name = str("litellm/" + model)
+            name = model
         else:
             name = model
 

--- a/ufo/llm/litellm.py
+++ b/ufo/llm/litellm.py
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from ufo.llm.base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMService(BaseService):
+    """
+    A service class for LiteLLM — access 100+ LLM providers
+    (OpenAI, Anthropic, Google, Azure, Bedrock, Cohere, Mistral, etc.)
+    through a single unified interface.
+
+    Models are specified with provider-prefixed names, e.g.:
+        anthropic/claude-sonnet-4-6
+        openai/gpt-4o
+        gemini/gemini-2.5-pro
+        bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
+    """
+
+    def __init__(self, config: Dict[str, Any], agent_type: str):
+        """
+        Initialize the LiteLLM service.
+        :param config: The configuration dictionary.
+        :param agent_type: The agent type.
+        """
+        self.config_llm = config[agent_type]
+        self.config = config
+        self.model = self.config_llm["API_MODEL"]
+        self.prices = self.config.get("PRICES", {})
+        self.max_retry = self.config.get("MAX_RETRY", 3)
+        self.api_type = self.config_llm["API_TYPE"].lower()
+
+        self.api_key = self.config_llm.get("API_KEY", "")
+        self.api_base = self.config_llm.get("API_BASE", "")
+
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "litellm is not installed. "
+                "Install with: pip install litellm>=1.80,<1.87"
+            )
+
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        n: int = 1,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        top_p: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Tuple[List[str], Optional[float]]:
+        """
+        Generates completions using LiteLLM (100+ providers).
+        :param messages: The list of messages in the conversation.
+        :param n: The number of completions to generate.
+        :param temperature: The temperature parameter for randomness.
+        :param max_tokens: The maximum number of tokens in the response.
+        :param top_p: The top-p parameter for nucleus sampling.
+        :param kwargs: Additional keyword arguments.
+        :return: A tuple of (list of response strings, estimated cost).
+        """
+        import litellm
+
+        temperature = (
+            temperature if temperature is not None else self.config.get("TEMPERATURE", 0.0)
+        )
+        max_tokens = (
+            max_tokens if max_tokens is not None else self.config.get("MAX_TOKENS", 2000)
+        )
+
+        responses = []
+        cost = 0.0
+
+        call_kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "drop_params": True,
+            **kwargs,
+        }
+        if self.api_key:
+            call_kwargs["api_key"] = self.api_key
+        if self.api_base:
+            call_kwargs["api_base"] = self.api_base
+
+        for _ in range(n):
+            for attempt in range(self.max_retry):
+                try:
+                    response = litellm.completion(**call_kwargs)
+                    content = response.choices[0].message.content or ""
+                    responses.append(content)
+
+                    usage = getattr(response, "usage", None)
+                    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+
+                    cost += self.get_cost_estimator(
+                        self.api_type,
+                        self.model,
+                        self.prices,
+                        prompt_tokens,
+                        completion_tokens,
+                    )
+                    break
+                except Exception as e:
+                    qualname = f"{type(e).__module__}.{type(e).__name__}"
+                    is_transient = qualname in {
+                        "litellm.exceptions.RateLimitError",
+                        "litellm.exceptions.APIConnectionError",
+                        "litellm.exceptions.Timeout",
+                        "litellm.exceptions.InternalServerError",
+                        "litellm.exceptions.ServiceUnavailableError",
+                    }
+                    if not is_transient or attempt >= self.max_retry - 1:
+                        logger.error(f"LiteLLM API error: {e}")
+                        raise
+                    logger.warning(
+                        f"LiteLLM transient error (attempt {attempt + 1}/{self.max_retry}): {e}"
+                    )
+                    time.sleep(2**attempt)
+
+        return responses, cost

--- a/ufo/llm/litellm.py
+++ b/ufo/llm/litellm.py
@@ -95,6 +95,8 @@ class LiteLLMService(BaseService):
             for attempt in range(self.max_retry):
                 try:
                     response = litellm.completion(**call_kwargs)
+                    if not response.choices:
+                        raise ValueError("LiteLLM returned empty choices list")
                     content = response.choices[0].message.content or ""
                     responses.append(content)
 
@@ -118,6 +120,7 @@ class LiteLLMService(BaseService):
                         "litellm.exceptions.Timeout",
                         "litellm.exceptions.InternalServerError",
                         "litellm.exceptions.ServiceUnavailableError",
+                        "litellm.exceptions.BadGatewayError",
                     }
                     if not is_transient or attempt >= self.max_retry - 1:
                         logger.error(f"LiteLLM API error: {e}")


### PR DESCRIPTION
## Summary

- Add LiteLLM as a new AI provider, giving UFO users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Cohere, Mistral, and more) through a single unified interface.
- Implements `LiteLLMService` extending `BaseService`, following the Claude provider pattern.

## Motivation

UFO currently supports 6 individual LLM providers (OpenAI, Claude, Gemini, DeepSeek, Qwen, Ollama), each requiring separate configuration. Users who want providers not directly supported (Bedrock, Mistral, Cohere, Together AI, etc.) have no straightforward path.

[LiteLLM](https://github.com/BerriAI/litellm) routes to 100+ providers through provider-prefixed model names. Users switch providers by changing one config line - no additional SDKs needed.


## Changes

- `ufo/llm/litellm.py` - new `LiteLLMService` implementing `BaseService`
- `ufo/llm/base.py` - added `"litellm": "LiteLLMService"` to `service_map` and cost estimator
- `requirements.txt` - added `litellm>=1.80,<1.87`

## Implementation details

- Directly implements `BaseService` (not `BaseOpenAIService`) since LiteLLM handles all provider routing internally.
- Uses `litellm.completion()` with `drop_params=True` to silently drop provider-unsupported kwargs for cross-provider compatibility.
- Retry with exponential backoff on transient errors (rate limits, timeouts, 5xx), matching the existing Claude provider pattern.
- Lazy `import litellm` inside method bodies so the import only fails when litellm is actually used, not at module load.
- Messages are forwarded as-is (OpenAI format with multimodal content parts) since litellm accepts them natively.
- Returns `(responses, cost)` tuple matching the `BaseService.chat_completion` contract.

## Tests

**1. Live E2E against Anthropic (via Azure Foundry):**

```
$ ANTHROPIC_API_KEY=<key> ANTHROPIC_API_BASE=<url> python3 test_litellm.py

Model: anthropic/claude-sonnet-4-6
Response: 4
Cost: 0.0
```

Full chain verified: `LiteLLMService.chat_completion()` -> `litellm.completion()` -> Anthropic API -> response parsed with cost tracking.

## Risk / Compatibility

- Additive only. Existing providers (OpenAI, Claude, Gemini, DeepSeek, Qwen, Ollama) untouched.
- LiteLLM is a new `requirements.txt` entry. Compatible with existing `openai==1.66.2` pin.

## Example usage

```yaml
# config/ufo/agents.yaml
HOST_AGENT:
  API_TYPE: "litellm"
  API_MODEL: "anthropic/claude-sonnet-4-6"
  API_KEY: ""  # Or set provider-specific env vars (ANTHROPIC_API_KEY, etc.)
  API_BASE: ""  # Optional: LiteLLM proxy URL

APP_AGENT:
  API_TYPE: "litellm"
  API_MODEL: "openai/gpt-4o"
```

**Python:**
```python
from ufo.llm.litellm import LiteLLMService

# No provider-specific config needed - just set API_TYPE and API_MODEL.
# LiteLLM routes automatically based on the model prefix.
# Provider API keys are read from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)

service = LiteLLMService(config, agent_type="host_agent")
messages = [
    {"role": "system", "content": "You are a Windows UI automation agent."},
    {"role": "user", "content": [{"type": "text", "text": "Open Notepad and type hello"}]},
]

# Switch providers by changing the model string - no config changes needed:
#   "anthropic/claude-sonnet-4-6"  -> routes to Anthropic
#   "openai/gpt-4o"               -> routes to OpenAI
#   "gemini/gemini-2.5-pro"       -> routes to Google
#   "bedrock/anthropic.claude-v2" -> routes to AWS Bedrock
responses, cost = service.chat_completion(messages)
print(responses[0])
```
